### PR TITLE
drop obsolete syslog.target from thinkfan.service

### DIFF
--- a/rcscripts/systemd/thinkfan.service
+++ b/rcscripts/systemd/thinkfan.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Thinkfan, the minimalist fan control program
-After=syslog.target
 
 [Service]
 Type=forking


### PR DESCRIPTION
the target is obsolete since systemd v38 which everybody should have.