### PR TITLE
changed script from runscript to openrc-run as runscript is deprecated

### DIFF
--- a/rcscripts/openrc/thinkfan.cmake
+++ b/rcscripts/openrc/thinkfan.cmake
@@ -1,4 +1,4 @@
-#!/sbin/runscript
+#!/sbin/openrc-run
 
 extra_started_commands="reload"
 


### PR DESCRIPTION
Running the current openrc script displays a warning that runscript is deprecated.  I just switched the hashbang to openrc-run and had no problems with starting, stopping, or reloading thinkfan.