### PR TITLE
Add missing include (fixes #47)

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -20,6 +20,7 @@
  * ******************************************************************/
 
 #include "config.h"
+#include <algorithm>
 #include <fstream>
 #include <limits>
 #include <cstring>


### PR DESCRIPTION
Added missing `#include <algorithm>` so that `std::for_each` could be found. Fixes #47 