### PR TITLE
allow 127 for the disengaged value, which is supported

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -131,7 +131,8 @@ const Config *Config::try_read_config(const string &filename)
 		error<ConfigError>(MSG_CONF_MAXLVL((*rv->levels_.rbegin())->num()));
 	else if (dynamic_cast<TpFanDriver *>(rv->fan())
 			 && maxlvl != std::numeric_limits<int>::max()
-			 && maxlvl > 7)
+			 && maxlvl > 7
+			 && maxlvl != 127)
 		error<ConfigError>(MSG_CONF_TP_LVL7(maxlvl, 7));
 
 	return rv;


### PR DESCRIPTION
thinkpad_acpi supports value 127 as "disengaged", which is quite often a lot faster than "max" speed. This used to be supported in older versions of thinkfan.