### PR TITLE
Fix watchdog ping timing

### DIFF
--- a/src/drivers.cpp
+++ b/src/drivers.cpp
@@ -144,7 +144,7 @@ void TpFanDriver::ping_watchdog_and_depulse(const Level *level)
 		std::this_thread::sleep_for(depulse_);
 		set_speed(level);
 	}
-	else if (last_watchdog_ping_ + watchdog_ + sleeptime >= std::chrono::system_clock::now())
+	else if (last_watchdog_ping_ + watchdog_ + sleeptime <= std::chrono::system_clock::now())
 		set_speed(level);
 }
 


### PR DESCRIPTION
The time comparison in ping_watchdog_and_depulse is backwards, causing the speed to be set every [sleeptime] seconds regardless of watchdog_. From the fact this hasn't been noticed yet I'm guessing this is not an issue for most users; but on my hardware setting the speed causes the fan to momentarily shut off, so this bug was causing the fan to ramp up and down every five seconds even when temperatures were steady. Please enjoy this 1 byte patch.