### PR TITLE
Fix atasmart temperature correction

### DIFF
--- a/src/drivers.cpp
+++ b/src/drivers.cpp
@@ -435,7 +435,7 @@ void AtasmartSensorDriver::read_temps() const
 			throw SystemError(MSG_T_GET(path_) + std::to_string(tmp) + " isn't a valid temperature.");
 		}
 
-		temp_state.add_temp(int(tmp));
+		temp_state.add_temp(int(tmp) + correction_[0]);
 	}
 }
 #endif /* USE_ATASMART */


### PR DESCRIPTION
Hi,
I have tried to make `thinkfan` to monitor HDD temperature using the simple mode
> atasmart /dev/sda (15)

However, `thinkfan` daemon ignores the temperature correction, which is evident by its logs(reported HDD temp is the same as real HDD temp w/o any correction).

So, I have made a trivial fix to enable the temperature correction for atasmart.