### PR TITLE
openrc runscript: modernize

### DIFF
--- a/rcscripts/openrc/thinkfan.cmake
+++ b/rcscripts/openrc/thinkfan.cmake
@@ -1,26 +1,19 @@
 #!/sbin/openrc-run
 
+command="@CMAKE_INSTALL_PREFIX@/sbin/thinkfan"
+command_args="-q -s5 -c /etc/thinkfan.conf"
+pidfile="@PID_FILE@"
+
 extra_started_commands="reload"
+
+required_files="/etc/thinkfan.conf"
 
 depend() {
 	after modules
 }
 
-start() {
-	ebegin "Starting thinkfan"
-	start-stop-daemon --start --exec @CMAKE_INSTALL_PREFIX@/sbin/thinkfan -- -q -s5 -c /etc/thinkfan.conf
-	eend $?
-}
-
-stop() {
-	ebegin "Stopping thinkfan"
-	start-stop-daemon --stop --exec @CMAKE_INSTALL_PREFIX@/sbin/thinkfan
-	eend $?
-}
-
 reload() {
-	PID=$(<@PID_FILE@)
-	ebegin "Sending SIGHUP to thinkfan($PID)"
-	kill -HUP $PID
+	ebegin "Reloading ${SVCNAME}"
+	start-stop-daemon --signal HUP --pidfile "${pidfile}"
 	eend $?
 }


### PR DESCRIPTION
- Use default start/stop method

- Set pidfile variable to make use of built-in status function

- Fix bashism

```
 * Please fix the ebuild to use correct FHS/Gentoo policy paths.
 * QA Notice: shell script appears to use non-POSIX feature(s):
 *    possible bashism in etc/init.d/thinkfan line 22 ('$(< foo)' should be '$(cat foo)'):
 *      PID=$(</var/run/thinkfan.pid)
```