### PR TITLE
Replaced __pid_t with pid_t

### DIFF
--- a/src/thinkfan.cpp
+++ b/src/thinkfan.cpp
@@ -251,7 +251,7 @@ int set_options(int argc, char **argv)
 }
 
 
-PidFileHolder::PidFileHolder(::__pid_t pid)
+PidFileHolder::PidFileHolder(::pid_t pid)
 : pid_file_(PID_FILE, std::ios_base::in)
 {
 	if (!pid_file_.fail())

--- a/src/thinkfan.h
+++ b/src/thinkfan.h
@@ -82,7 +82,7 @@ public:
 
 class PidFileHolder {
 public:
-	PidFileHolder(::__pid_t pid);
+	PidFileHolder(::pid_t pid);
 	~PidFileHolder();
 	static bool file_exists();
 private:


### PR DESCRIPTION
Make thinkfan compatible with MUSL (glibc replacement) library. From the MUSL docs:

When applications that work with glibc fail to compile against musl, the cause will usually be one of the following:
...
- Using implementation details from the glibc headers which were not meant to be exposed to applications. This is also an application bug, and it can usually be fixed by search-and-replace (e.g. replacing __pid_t with pid_t in the source).
...

I replaced __pid_t with pid_t in the code.