### PR TITLE
Add support for searching hwmon sensors by name

### DIFF
--- a/examples/thinkfan.conf.yaml
+++ b/examples/thinkfan.conf.yaml
@@ -2,6 +2,10 @@ sensors:
   - hwmon: /sys/class/graphics/fb0/device/hwmon
     indices: [1, 3]
 
+  #- hwmon: /sys/devices/virtual/thermal
+  #  name: pch_skylake
+  #  indices: [1]
+
   #- tpacpi: /proc/acpi/ibm/thermal
 
 fans:

--- a/src/message.h
+++ b/src/message.h
@@ -152,6 +152,8 @@ template<class ErrT, class... ArgTs> void error(ArgTs... args) {
 #define MSG_T_GET(file) string(__func__) + ": Failed to read temperature(s) from " + file + ": "
 #define MSG_T_INVALID(s, d) s + ": Invalid temperature: " + std::to_string(d)
 #define MSG_SENSOR_INIT(file) string(__func__) + ": Initializing sensor in " + file + ": "
+#define MSG_HWMON_NOT_FOUND "Could not find a hwmon with this name"
+#define MSG_MULTIPLE_HWMONS_FOUND "Found multiple hwmons with this name: "
 
 
 #define MSG_FAN_MODOPTS \

--- a/src/yamlconfig.cpp
+++ b/src/yamlconfig.cpp
@@ -33,6 +33,9 @@ static const string kw_atasmart("atasmart");
 static const string kw_speed("speed");
 static const string kw_upper("upper_limit");
 static const string kw_lower("lower_limit");
+static const string kw_name("name");
+static const string kw_self(".");
+static const string kw_parent("..");
 static const string kw_indices("indices");
 static const string kw_correction("correction");
 
@@ -106,6 +109,11 @@ static int filter_hwmon_dirs(const struct dirent *entry)
 	return 0;
 }
 
+static int filter_subdirs(const struct dirent *entry)
+{
+	return entry->d_type & DT_DIR && entry->d_name != kw_self && entry->d_name != kw_parent;
+}
+
 
 template<class T>
 static int scandir(const string &path, struct dirent ***entries);
@@ -119,9 +127,42 @@ int scandir< HwmonFanDriver > (const string &path, struct dirent ***entries)
 { return ::scandir(path.c_str(), entries, filter_pwms, alphasort); }
 
 
+static vector<string> find_hwmons_by_name(string path, string name, unsigned char depth = 1) {
+	const unsigned char max_depth = 5;
+	vector<string> result;
+
+	ifstream f(path + "/name");
+	if (f.is_open() && f.good()) {
+		string tmp;
+		if ((f >> tmp) && tmp == name) {
+			result.push_back(path);
+			return result;
+		}
+	}
+	if (depth >= max_depth) {
+		return result;  // don't recurse to subdirs
+	}
+
+	struct dirent **entries;
+	int nentries = ::scandir(path.c_str(), &entries, filter_subdirs, NULL);
+	if (nentries == -1) {
+		return result;
+	}
+	for (int i = 0; i < nentries; i++) {
+		auto subdir = path + "/" + entries[i]->d_name;
+		free(entries[i]);
+
+		auto found = find_hwmons_by_name(subdir, name, depth + 1);
+		result.insert(result.end(), found.begin(), found.end());
+	}
+	free(entries);
+
+	return result;
+}
+
 
 template<class T>
-static vector<wtf_ptr<T>> find_hwmons(string path, const vector<int> &indices)
+static vector<wtf_ptr<T>> find_hwmons_by_indices(string path, const vector<int> &indices)
 {
 	vector<wtf_ptr<T>> rv;
 
@@ -193,9 +234,27 @@ struct convert<vector<wtf_ptr<HwmonSensorDriver>>> {
 		if (node[kw_correction])
 			correction = node[kw_correction].as<vector<int>>();
 
+		if (node[kw_name]) {
+			auto paths = find_hwmons_by_name(path, node[kw_name].as<string>());
+			if (paths.size() != 1) {
+				string msg;
+				if (paths.size() == 0) {
+					msg = MSG_HWMON_NOT_FOUND;
+				} else {
+					msg = MSG_MULTIPLE_HWMONS_FOUND;
+					for (string hwmon_path : paths) {
+						msg += " " + hwmon_path;
+					}
+				}
+				throw YamlError(get_mark_compat(node[kw_name]), msg);
+			}
+			path = paths[0];
+		}
+
 		if (node[kw_indices]) {
-			vector<wtf_ptr<HwmonSensorDriver>> hwmons = find_hwmons<HwmonSensorDriver>(
-						path, node[kw_indices].as<vector<int>>());
+			vector<wtf_ptr<HwmonSensorDriver>> hwmons = find_hwmons_by_indices<HwmonSensorDriver>(
+						path,
+						node[kw_indices].as<vector<int>>());
 			if (!correction.empty()) {
 				if (correction.size() != hwmons.size())
 					throw YamlError(
@@ -344,7 +403,7 @@ struct convert<vector<wtf_ptr<HwmonFanDriver>>> {
 		string path = node[kw_hwmon].as<string>();
 
 		if (node[kw_indices])
-			fans = find_hwmons<HwmonFanDriver>(path, node[kw_indices].as<vector<int>>());
+			fans = find_hwmons_by_indices<HwmonFanDriver>(path, node[kw_indices].as<vector<int>>());
 		else
 			fans.push_back(make_wtf<HwmonFanDriver>(node[kw_hwmon].as<string>()));
 


### PR DESCRIPTION
Add a new config directive `thermal_zone name` which searches /sys/devices/virtual/thermal for a file called `name`. It its content matches the name, use the `temp1_input` next to it as the temperature input.

Fixes #43 