### PR TITLE
WIP: Warn about unusual sensor readings

### DIFF
--- a/src/drivers.cpp
+++ b/src/drivers.cpp
@@ -25,6 +25,7 @@
 #include "config.h"
 
 #include <fstream>
+#include <sstream>
 #include <cstring>
 #include <thread>
 #include <typeinfo>
@@ -403,6 +404,13 @@ void TpSensorDriver::read_temps() const
 	int tmp;
 	while (!(f.eof() || f.fail())) {
 		f >> tmp;
+		if (tmp < 0) {
+			std::stringstream ss;
+			ss << "Getting unusual values from thermal sensor (";
+			ss << tmp;
+			ss << "). Are you using right thermal sensor?";
+			log(TF_NFY) << ss.str() << flush;
+		}
 		if (f.bad())
 			throw IOerror(MSG_T_GET(path_), errno);
 		if (!f.fail() && in_use_[tidx])


### PR DESCRIPTION
Related issue: #77

This PR attempts to warn user about unusual sensors readings by log messages. In current state it is more like crude attempt and I am open to suggestions, how to make this PR better.

There certainly is room for improvements, just to mention few:
* Is there a generic way to report such readings from any `SensorDriver` instead of impletement it in every driver `read_temps()`?
* Is it better to use string/stringstream in section of code or predefined string using `#define` in header file?

 