### PR TITLE
Restart thinkfan.service when failing to read temp input.

### DIFF
--- a/rcscripts/systemd/thinkfan.service
+++ b/rcscripts/systemd/thinkfan.service
@@ -6,6 +6,8 @@ Type=forking
 ExecStart=/usr/local/sbin/thinkfan $THINKFAN_ARGS
 PIDFile=/run/thinkfan.pid
 ExecReload=/bin/kill -HUP $MAINPID
+Restart=Always
+RestartSec=3
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Sometimes thinkfan fails reading temp_input after waking up from sleep. If it fails it the bios will end up doing the fan control. Just forcing the service to restart on failure fixes the issue.