### PR TITLE
Fix option lists in man page and help message

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To compile thinkfan, you will need to have the following things installed:
 
 2. Then configure your build, either interactively:
    ```bash
-   cmake ..
+   ccmake ..
    ```
    Or set your build options from the command line. E.g. to configure a build
    with full debugging support:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To compile thinkfan, you will need to have the following things installed:
 
 2. Then configure your build, either interactively:
    ```bash
-   ccmake ..
+   cmake ..
    ```
    Or set your build options from the command line. E.g. to configure a build
    with full debugging support:

--- a/src/message.h
+++ b/src/message.h
@@ -115,12 +115,13 @@ template<class ErrT, class... ArgTs> void error(const ArgTs &... args) {
 #define MSG_TITLE "thinkfan " VERSION ": A minimalist fan control program"
 
 #define MSG_USAGE \
- "Usage: thinkfan [-hnqzD [-b BIAS] [-c CONFIG] [-s SECONDS] [-p [SECONDS]]]" \
+ "Usage: thinkfan [-hnqDd [-b BIAS] [-c CONFIG] [-s SECONDS] [-p [SECONDS]]]" \
  "\n -h  This help message" \
  "\n -s  Maximum cycle time in seconds (Integer. Default: 5)" \
  "\n -b  Floating point number (-10 to 30) to control rising temperature" \
  "\n     exaggeration (see README). Default: 5.0" \
  "\n -c  Load different configuration file (default: /etc/thinkfan.conf)" \
+ "\n -n  Do not become a daemon and log to terminal instead of syslog" \
  "\n -q  Be more quiet. Can be specified up to three times so that only errors" \
  "\n     are logged." \
  "\n -v  Enable verbose logging (e.g. log temperatures continuously)." \

--- a/src/thinkfan.1
+++ b/src/thinkfan.1
@@ -3,7 +3,7 @@
 thinkfan \- A simple fan control program
 .SH SYNOPSIS
 .SY thinkfan
-.OP \-hnqzDd
+.OP \-hnqDd
 .OP \-b BIAS
 .OP \-c CONFIG
 .OP \-s SECONDS


### PR DESCRIPTION
- Fix minor (but confusing to me, unfamiliar with `cmake`) typo in README
- Add -n to option list description shown in help text
- Add -d to and remove -z from option list shown in help text
- Remove -z from option list in man page

I thought I was losing my mind after upgrading and not seeing an option to log to stdout in the help text.