### PR TITLE
Fix incompatibility when using libcxx

### DIFF
--- a/src/error.cpp
+++ b/src/error.cpp
@@ -26,6 +26,7 @@
 #include <execinfo.h>
 #endif
 
+#include <array>
 #include <cstring>
 #include <sstream>
 
@@ -100,7 +101,7 @@ const string &Error::backtrace() const
 { return backtrace_; }
 
 
-const char* Error::what() const _GLIBCXX_USE_NOEXCEPT
+const char* Error::what() const noexcept
 { return msg_.c_str(); }
 
 
@@ -173,7 +174,7 @@ const string &ConfigError::filename() const
 const string &ConfigError::reason() const
 { return reason_; }
 
-const char* ConfigError::what() const _GLIBCXX_USE_NOEXCEPT
+const char* ConfigError::what() const noexcept
 { return msg_.c_str(); }
 
 

--- a/src/error.h
+++ b/src/error.h
@@ -55,7 +55,7 @@ protected:
 public:
 	Error(const string &message = "");
 
-	virtual const char* what() const _GLIBCXX_USE_NOEXCEPT override;
+	virtual const char* what() const noexcept override;
 	const string &backtrace() const;
 };
 
@@ -115,7 +115,7 @@ public:
 	void set_filename(const string &filename);
 	const string &filename() const;
 	const string &reason() const;
-	virtual const char* what() const _GLIBCXX_USE_NOEXCEPT override;
+	virtual const char* what() const noexcept override;
 #ifdef USE_YAML
 	ConfigError(const string &filename, const YAML::Mark &mark, const string &input, const string &msg);
 #endif


### PR DESCRIPTION
This commit fixes a compilation problem when using libcxx instead of stdlibc++ on Clang.