### PR TITLE
Remove path on sleep command

### DIFF
--- a/rcscripts/systemd/thinkfan-sleep.service
+++ b/rcscripts/systemd/thinkfan-sleep.service
@@ -6,7 +6,7 @@ Before=sleep.target
 Type=oneshot
 ExecStart=/usr/bin/pkill -x -pwr thinkfan
 # Hack: Since the signal handler races with the sleep, we need to delay a bit
-ExecStart=/usr/bin/sleep 1
+ExecStart=sleep 1
 
 [Install]
 WantedBy=sleep.target


### PR DESCRIPTION
sleep is traditionally installed to /bin/. Only systems with merged
/usr/{bin,lib,sbin}/ directories have it in /usr/bin/.

This fixes at least one issue people are having with this service. The other options are using /bin/sleep instead. This will also work on merged /usr/ systems, as /bin will symlink to /usr/bin/ where the binary is.

It's probably also a good idea to remove the full path on all other commands, too. But so far I haven't seen any issue with those.