### PR TITLE
run systemd service with realtime priority

### DIFF
--- a/rcscripts/systemd/thinkfan.service.cmake
+++ b/rcscripts/systemd/thinkfan.service.cmake
@@ -8,6 +8,8 @@ Type=forking
 ExecStart=@CMAKE_INSTALL_PREFIX@/sbin/thinkfan $THINKFAN_ARGS
 PIDFile=/run/thinkfan.pid
 ExecReload=/bin/kill -HUP $MAINPID
+CPUSchedulingPolicy=fifo
+CPUSchedulingPriority=20
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Run systemd service with realtime priority, to ensure that thinkfan's execution is not delayed in case of sudden rise of CPU load. Deactivated fans on heavy CPU load could otherwise lead to a system freeze.