### PR TITLE
Add cppcheck github workflow

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -1,0 +1,36 @@
+name: cppcheck-action-test
+on:
+  pull_request:
+
+jobs:
+  build:
+    name: cppcheck-test
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      checks: write
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install-deps
+        run: sudo apt install libyaml-cpp-dev libatasmart-dev cmake libsensors4-dev cppcheck
+      - name: build
+        run: |
+          mkdir build
+          cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE:STRING=Debug -DUSE_ATASMART:BOOL=ON
+          cmake --build build
+
+      - name: cppcheck
+        uses: deep5050/cppcheck-action@main
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # enable: all
+          # other_options: --addon=threadsafety.py --project=build/compile_commands.json -ibuild
+
+      - name: publish report
+        uses: mikeal/publish-to-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH_NAME: 'master'

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Ignore the build directory
+build/
+
+# Ignore cppcheck artifacts
+*.ctu-info
+
+# Ignore ctags file
+tags


### PR DESCRIPTION
This workflow will require a project token added to GITHUB_TOKEN name in the project settings:

https://docs.github.com/en/codespaces/managing-codespaces-for-your-organization/managing-encrypted-secrets-for-your-repository-and-organization-for-github-codespaces#adding-secrets-for-a-repository

This will allow the cppcheck report to be attached to the run of the action.

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>