### PR TITLE
Fixing unexpected short fan activation when on level "0" for new gen Thinkpads

### DIFF
--- a/src/fans.cpp
+++ b/src/fans.cpp
@@ -139,7 +139,11 @@ void TpFanDriver::ping_watchdog_and_depulse(const Level &level)
 	}
 	else if (last_watchdog_ping_ + watchdog_ - sleeptime <= std::chrono::system_clock::now()) {
 		log(TF_DBG) << "Watchdog ping" << flush;
-		set_speed(level);
+		std::fstream f(path_);
+		if (!(f.is_open() && f.good()))
+			throw IOerror(MSG_FAN_INIT(path_), errno);
+		if (!(f << "watchdog " << watchdog_.count() << std::flush))
+			throw IOerror(MSG_FAN_INIT(path_), errno);
 	}
 }
 


### PR DESCRIPTION
As per issue #114, on newer Thinkpads (at least AMD Thinkpad E14 gen 2 and gen 6 affected) when the fan speed is set to "level 0", the fan spins up up very briefly around every 120 seconds.

In fact, the kernel's [thinkpad-acpi](https://www.kernel.org/doc/Documentation/admin-guide/laptops/thinkpad-acpi.rst) documentation states that :
> The thinkpad-acpi kernel driver can be programmed to revert the fan level to a safe setting if userspace does not issue one of the procfs fan commands: "enable", "disable", "level" or "watchdog", or if there are no writes to pwm1_enable (or to pwm1 *if and only if* pwm1_enable is set to 1, manual mode) within a configurable amount of time of up to 120 seconds.  This functionality is called fan safety watchdog.

As such, to prevent the watchdog from resetting the fan to "automatic", Thinkfan resets the fan speed every 120 second to the current level.

However at low temperature, and if the speed is set to "level 0", rewriting 'level 0' to /proc/acpi/ibm/fan causes the fan to spin up for half a second or so.

This pull request proposes an alternative to resetting the fan speed in order to prevent the watchdog reset (as per @pennae proposition).

Fixes vmatare/thinkfan#114 