### PR TITLE
update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ To compile thinkfan, you will need to have the following things installed:
 
 E.g. on a debian-based system that usually boils down to:
 ```bash
-sudo apt install -y cmake-curses-gui build-essential cmake g++ libyaml-cpp-dev pkgconfig libsensors-dev
+sudo apt install -y cmake-curses-gui build-essential cmake g++ libyaml-cpp-dev pkg-config libsensors-dev
 ```
 
 on EL/Fedora based system, usually :
 ```bash
-sudo dnf install -y cmake g++ pkgconfig yaml-cpp-devel lm_sensors-devel
+sudo dnf install -y cmake g++ pkg-config yaml-cpp-devel lm_sensors-devel
 ```
 
 1. In the thinkfan main directory, do


### PR DESCRIPTION
when install with apt or dnf this Error: Unable to locate package pkgconfig gets displayed
the cause is the name of pkgconfig is missing a " - " to be pkg-config

fix for README.md pkg-config #255