### PR TITLE
add skip_save option to workaround some systems

### DIFF
--- a/src/fans.cpp
+++ b/src/fans.cpp
@@ -210,16 +210,20 @@ HwmonFanDriver::HwmonFanDriver(const string &path)
 HwmonFanDriver::HwmonFanDriver(
 	shared_ptr<HwmonInterface<FanDriver>> hwmon_interface,
 	bool optional,
-	opt<unsigned int> max_errors
+	opt<unsigned int> max_errors,
+	bool skip_save
 )
 : FanDriver(optional, 0, max_errors)
 , hwmon_interface_(hwmon_interface)
+, skip_save_(skip_save)
 {}
 
 
 HwmonFanDriver::~HwmonFanDriver() noexcept(false)
 {
 	if (!initialized())
+		return;
+	if (skip_save_)
 		return;
 
 	std::ofstream f(path() + "_enable");
@@ -238,6 +242,8 @@ HwmonFanDriver::~HwmonFanDriver() noexcept(false)
 
 void HwmonFanDriver::init()
 {
+	if (skip_save_)
+		return;
 	std::fstream f(path() + "_enable");
 	if (!(f.is_open() && f.good()))
 		throw IOerror(MSG_FAN_INIT(path()), errno);

--- a/src/fans.h
+++ b/src/fans.h
@@ -83,7 +83,8 @@ public:
 	HwmonFanDriver(
 		shared_ptr<HwmonInterface<FanDriver>> hwmon_interface,
 		bool optional,
-		opt<unsigned int> max_errors = nullopt
+		opt<unsigned int> max_errors = nullopt,
+		bool skip_save = false
 	);
 
 	virtual ~HwmonFanDriver() noexcept(false) override;
@@ -96,6 +97,7 @@ protected:
 
 private:
 	shared_ptr<HwmonInterface<FanDriver>> hwmon_interface_;
+	bool skip_save_;
 };
 
 

--- a/src/yamlconfig.cpp
+++ b/src/yamlconfig.cpp
@@ -280,7 +280,7 @@ bool convert_driver<vector<wtf_ptr<HwmonFanDriver>>>(const Node &node, vector<wt
 		return false;
 
 	allowed_keywords(node, {
-		kw_hwmon, kw_name, kw_indices, kw_optional, kw_max_errors, kw_levels
+		kw_hwmon, kw_name, kw_indices, kw_optional, kw_max_errors, kw_levels, kw_skip_save
 	});
 
 	string path = node[kw_hwmon].as<string>();
@@ -289,6 +289,7 @@ bool convert_driver<vector<wtf_ptr<HwmonFanDriver>>>(const Node &node, vector<wt
 	bool optional = node[kw_optional] ? node[kw_optional].as<bool>() : false;
 	opt<vector<unsigned int>> indices = decode_opt<vector<unsigned int>>(node[kw_indices]);
 	opt<unsigned int> max_errors = decode_opt<unsigned int>(node[kw_max_errors]);
+	bool skip_save = node[kw_skip_save] ? node[kw_skip_save].as<bool>() : false;
 
 	shared_ptr<HwmonInterface<FanDriver>> hwmon_iface = std::make_shared<HwmonInterface<FanDriver>>(
 		path, name, model, indices
@@ -301,7 +302,7 @@ bool convert_driver<vector<wtf_ptr<HwmonFanDriver>>>(const Node &node, vector<wt
 		);
 
 	for (unsigned int i = 0; i < (indices ? indices->size() : 1); ++i)
-		fans.push_back(wtf_ptr<HwmonFanDriver>(new HwmonFanDriver(hwmon_iface, optional, max_errors)));
+		fans.push_back(wtf_ptr<HwmonFanDriver>(new HwmonFanDriver(hwmon_iface, optional, max_errors, skip_save)));
 
 	return true;
 }

--- a/src/yamlconfig.h
+++ b/src/yamlconfig.h
@@ -36,6 +36,7 @@ const string kw_indices("indices");
 const string kw_correction("correction");
 const string kw_optional("optional");
 const string kw_max_errors("max_errors");
+const string kw_skip_save("skip_save");
 
 
 template<>


### PR DESCRIPTION
This option skips checking "pwm1_enable" file and saving initial state of it, so that it can work on systems where this file is not readable.

This is a proposed solution to #257. Note that all documentation are not updated (yet). If this approach is approved, I can work on patches for documentation and examples.